### PR TITLE
Porting AzDO Pipelines to GitHub Actions

### DIFF
--- a/.github/workflows/pull-request/scala-style.yml
+++ b/.github/workflows/pull-request/scala-style.yml
@@ -1,0 +1,22 @@
+name: Scala CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Run scalastyle
+      run: sbt scalastyle test:scalastyle


### PR DESCRIPTION
For us to make our pipeline results available to external contributors, we must port our internal pipeline to a set of GitHub Actions.